### PR TITLE
[fix] nginx.confの修正

### DIFF
--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -1,10 +1,21 @@
-events {}
-http {
-    server {
-        listen 80;
-        # server_name localhost;#ここはあってもなくても正常に動作する
-        location / {
-            proxy_pass http://host.docker.internal:8080; # host.docker.internalでは正常に動くが、127.0.0.1ではうまくいかない
-        }
+map $http_upgrade $connection_upgrade { 
+    default upgrade;
+    ''      close;
+} 
+
+
+server {
+    #listen 80;→あっても正常に動作するかもしれないが未確認
+    # server_name localhost;#ここはあってもなくても正常に動作する→ec2上では下記のように記載しないと動かなかった。
+    # server_name localhost IPアドレス;
+
+    # Upgrade ヘッダと Connection ヘッダを明示的にバックエンドに渡さないとwebsocket errorとなる
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    location / {
+        proxy_pass http://host.docker.internal:8080; # host.docker.internalでは正常に動くが、127.0.0.1ではうまくいかない
     }
 }


### PR DESCRIPTION
修正前のconfではaws上のec2でリバースプロキシすることができなかったので、修正した。